### PR TITLE
Fix font spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ c.action(function(file){
     // Get the page to create the PDF.
     (async () => {
 	try{
-	    var launchConfig = {};
+	    var launchConfig = {args: ['--font-render-hinting=none']};
 	    if(c.executablePath){
 		console.log('Using chrome executable: '+c.executablePath);
 		launchConfig.executablePath = c.executablePath;


### PR DESCRIPTION
Font spacing was wrong without using --font-render-hinting=none. An alternative to hard-coding this would be to expose the font-render-hinting flag in chromehtml2pdf.

See https://github.com/puppeteer/puppeteer/issues/2410.